### PR TITLE
Pdo refactoring - add DataSource, build_graph

### DIFF
--- a/graphs/algorithms/src/kruskal.rs
+++ b/graphs/algorithms/src/kruskal.rs
@@ -2,25 +2,6 @@ use graph::Graph;
 
 /// Uses Kruskal's algorithm to calculate weight of graph minimum spanning tree
 ///
-/// # Example
-/// ```
-/// use graph::build_graph_from_string;
-/// use algorithms::calculate_min_total_weight;
-///
-/// let input = String::from("3 4
-/// 1 2 100
-/// 2 1 80
-/// 3 1 90
-/// 1 3 110
-/// ");
-///
-/// let graph = build_graph_from_string(input).unwrap();
-///
-/// let result = calculate_min_total_weight(graph);
-///
-/// assert_eq!(result, 170);
-/// ```
-///
 /// # Arguments
 ///
 /// * 'graph' - connected graph that will be used to calculate weight of minimum spanning tree

--- a/graphs/algorithms/src/kruskal.rs
+++ b/graphs/algorithms/src/kruskal.rs
@@ -2,6 +2,25 @@ use graph::Graph;
 
 /// Uses Kruskal's algorithm to calculate weight of graph minimum spanning tree
 ///
+/// # Example
+/// ```
+/// use graph::build_graph_from_string;
+/// use algorithms::calculate_min_total_weight;
+///
+/// let input = String::from("3 4
+/// 1 2 100
+/// 2 1 80
+/// 3 1 90
+/// 1 3 110
+/// ");
+///
+/// let graph = build_graph_from_string(input).unwrap();
+///
+/// let result = calculate_min_total_weight(graph);
+///
+/// assert_eq!(result, 170);
+/// ```
+///
 /// # Arguments
 ///
 /// * 'graph' - connected graph that will be used to calculate weight of minimum spanning tree

--- a/graphs/algorithms/src/lib.rs
+++ b/graphs/algorithms/src/lib.rs
@@ -1,8 +1,27 @@
 //! Implementation of few graph theory algorithms
 //!
-//! # Algorithms:
+//! # Algorithms
 //!
-//! * Kruskal's algorithm
+//! * Kruskal's algorithm ([`calculate_min_total_weight`])
+//!
+//! # Example
+//! ```
+//! use graph::build_graph_from_string;
+//! use algorithms::calculate_min_total_weight;
+//!
+//! let input = String::from("3 4
+//! 1 2 100
+//! 2 1 80
+//! 3 1 90
+//! 1 3 110
+//! ");
+//!
+//! let graph = build_graph_from_string(input).unwrap();
+//!
+//! let minimum_spanning_tree_weight = calculate_min_total_weight(graph);
+//!
+//! assert_eq!(minimum_spanning_tree_weight, 170);
+//! ```
 
 // extern these crates only when running tests
 #[cfg(test)]

--- a/graphs/algorithms/src/lib.rs
+++ b/graphs/algorithms/src/lib.rs
@@ -6,17 +6,16 @@
 //!
 //! # Example
 //! ```
-//! use graph::build_graph_from_string;
+//! use graph::Graph;
 //! use algorithms::calculate_min_total_weight;
 //!
-//! let input = String::from("3 4
-//! 1 2 100
-//! 2 1 80
-//! 3 1 90
-//! 1 3 110
-//! ");
-//!
-//! let graph = build_graph_from_string(input).unwrap();
+//! let graph: Graph = "3 4
+//!     1 2 100
+//!     2 1 80
+//!     3 1 90
+//!     1 3 110"
+//!     .parse()
+//!     .unwrap();
 //!
 //! let minimum_spanning_tree_weight = calculate_min_total_weight(graph);
 //!

--- a/graphs/algorithms/tests/acceptance_tests.rs
+++ b/graphs/algorithms/tests/acceptance_tests.rs
@@ -1,5 +1,6 @@
 use algorithms::calculate_min_total_weight;
-use graph::build_graph_from_file;
+use graph::build_graph;
+use std::path::PathBuf;
 use test_case::test_case;
 
 // -----------------------------------------------------------------------------
@@ -13,6 +14,11 @@ use test_case::test_case;
 #[test_case(7 => 1500)]
 #[test_case(8 => 400)]
 fn passing(dataset_number: u32) -> i32 {
-    let graph = build_graph_from_file(format!("tests/data/passing{}.txt", dataset_number)).unwrap();
+    let mut path = PathBuf::from("tests/data/passing");
+    path.push(format!("{}", dataset_number));
+    path.set_extension("txt");
+
+    let graph = build_graph(&path).unwrap();
+
     calculate_min_total_weight(graph)
 }

--- a/graphs/graph/src/errors.rs
+++ b/graphs/graph/src/errors.rs
@@ -17,16 +17,15 @@ pub type Result<T, E = BuildGraphError> = std::result::Result<T, E>;
 ///
 /// [`crate::build_graph_from_string`] should return an [`BuildGraphError::AddingEdgeError`]
 /// ```
-/// use graph::{build_graph_from_string, BuildGraphError, AddingEdgeError};
+/// use graph::{Graph, BuildGraphError, AddingEdgeError, Result};
 ///
-/// let input = String::from("3 2
-/// 1 2 100
-/// 2 4 100");
+/// let maybe_graph: Result<Graph> = "3 2
+///     1 2 100
+///     2 4 100"
+///     .parse();
 ///
-/// let result = build_graph_from_string(input);
-///
-/// assert!(result.is_err());
-/// assert_eq!(result.unwrap_err().to_string(),
+/// assert!(maybe_graph.is_err());
+/// assert_eq!(maybe_graph.unwrap_err().to_string(),
 ///     BuildGraphError::ErrorInGraphDescriptionFile {
 ///     line_no: 2,
 ///     error: Box::from(BuildGraphError::from(AddingEdgeError::WrongToIndex {
@@ -40,16 +39,15 @@ pub type Result<T, E = BuildGraphError> = std::result::Result<T, E>;
 ///
 /// [`crate::build_graph_from_string`] should return [`BuildGraphError::TooFewEdges`]
 /// ```
-/// use graph::{build_graph_from_string, BuildGraphError};
+/// use graph::{Graph, BuildGraphError, Result};
 ///
-/// let input = String::from("4 3
-/// 1 2 500
-/// 1 4 350");
+/// let maybe_graph: Result<Graph> = "4 3
+///     1 2 500
+///     1 4 350"
+///     .parse();
 ///
-/// let result = build_graph_from_string(input);
-///
-/// assert!(result.is_err());
-/// assert_eq!(result.unwrap_err().to_string(),
+/// assert!(maybe_graph.is_err());
+/// assert_eq!(maybe_graph.unwrap_err().to_string(),
 ///     BuildGraphError::TooFewEdges {
 ///     current_count: 2,
 ///     declared: 3,

--- a/graphs/graph/src/errors.rs
+++ b/graphs/graph/src/errors.rs
@@ -9,8 +9,52 @@ pub type Result<T, E = BuildGraphError> = std::result::Result<T, E>;
 
 /// Enum containing all possible variants of errors returned by functions in this crate.
 ///
-/// Derives [`thiserror::Error`] and [`core::fmt::Debug`], so errors could be easily printed out (using [`parse_display::Display`].
+/// Derives [`thiserror::Error`] and [`core::fmt::Debug`], so errors could be easily printed out (using [`parse_display::Display`]).
 /// Some errors contain variant of more specific enums.
+///
+/// # Examples
+/// Input contains edge that connects nodes '2' and '4', but declared number of nodes is 3
+///
+/// [`crate::build_graph_from_string`] should return an [`BuildGraphError::AddingEdgeError`]
+/// ```
+/// use graph::{build_graph_from_string, BuildGraphError, AddingEdgeError};
+///
+/// let input = String::from("3 2
+/// 1 2 100
+/// 2 4 100");
+///
+/// let result = build_graph_from_string(input);
+///
+/// assert!(result.is_err());
+/// assert_eq!(result.unwrap_err().to_string(),
+///     BuildGraphError::ErrorInGraphDescriptionFile {
+///     line_no: 2,
+///     error: Box::from(BuildGraphError::from(AddingEdgeError::WrongToIndex {
+///         edge: "2 4 100".parse().unwrap(),
+///         nodes_count: 3
+///     })),
+/// }.to_string());
+/// ```
+///
+/// Input contains only 2 edges, but declared number of edges is 3
+///
+/// [`crate::build_graph_from_string`] should return [`BuildGraphError::TooFewEdges`]
+/// ```
+/// use graph::{build_graph_from_string, BuildGraphError};
+///
+/// let input = String::from("4 3
+/// 1 2 500
+/// 1 4 350");
+///
+/// let result = build_graph_from_string(input);
+///
+/// assert!(result.is_err());
+/// assert_eq!(result.unwrap_err().to_string(),
+///     BuildGraphError::TooFewEdges {
+///     current_count: 2,
+///     declared: 3,
+/// }.to_string());
+/// ```
 #[derive(Error, Debug)]
 pub enum BuildGraphError {
     /// Kruskal's algorithm finds minimum spanning tree for connected graphs -

--- a/graphs/graph/src/lib.rs
+++ b/graphs/graph/src/lib.rs
@@ -4,15 +4,14 @@
 //!
 //! # Example
 //! ```
-//! use graph::build_graph_from_string;
+//! use graph::{build_graph_from_string, Graph};
 //!
-//! let input = String::from("4 3
-//! 1 2 150
-//! 1 3 220
-//! 4 2 140
-//! ");
-//!
-//! let graph = build_graph_from_string(input).unwrap();
+//! let graph: Graph = "4 3
+//!     1 2 150
+//!     1 3 220
+//!     4 2 140"
+//!     .parse()
+//!     .unwrap();
 //!
 //! assert_eq!(graph.nodes_count, 4);
 //! assert_eq!(graph.edges.len(), 3);

--- a/graphs/graph/src/lib.rs
+++ b/graphs/graph/src/lib.rs
@@ -1,6 +1,28 @@
-//! Implementation of graph structure and few graph algorithms
+//! Implementation of directed graph structure
 //!
 //! Result type for functions in this crate is [`crate::errors::Result`]
+//!
+//! # Example
+//! ```
+//! use graph::build_graph_from_string;
+//!
+//! let input = String::from("4 3
+//! 1 2 150
+//! 1 3 220
+//! 4 2 140
+//! ");
+//!
+//! let graph = build_graph_from_string(input).unwrap();
+//!
+//! assert_eq!(graph.nodes_count, 4);
+//! assert_eq!(graph.edges.len(), 3);
+//!
+//! let second_edge = graph.edges[1];
+//!
+//! assert_eq!(second_edge.from_index, 1);
+//! assert_eq!(second_edge.to_index, 3);
+//! assert_eq!(second_edge.weight, 220);
+//! ```
 
 // extern these crates only when running tests
 #[cfg(test)]

--- a/graphs/graph/src/lib.rs
+++ b/graphs/graph/src/lib.rs
@@ -13,4 +13,4 @@ mod structures;
 
 pub use crate::errors::{AddingEdgeError, BuildGraphError, GraphParametersParsingError, ParsingEdgeError, Result};
 pub use crate::reader::{build_graph_from_file, build_graph_from_string};
-pub use crate::structures::{Edge, EdgeDescription, Graph};
+pub use crate::structures::{Edge, EdgeDescription, Graph, GraphBuilder, GraphParameters};

--- a/graphs/graph/src/lib.rs
+++ b/graphs/graph/src/lib.rs
@@ -12,5 +12,5 @@ mod reader;
 mod structures;
 
 pub use crate::errors::{AddingEdgeError, BuildGraphError, GraphParametersParsingError, ParsingEdgeError, Result};
-pub use crate::reader::build_graph_from_file;
+pub use crate::reader::{build_graph_from_file, build_graph_from_string};
 pub use crate::structures::{Edge, EdgeDescription, Graph};

--- a/graphs/graph/src/lib.rs
+++ b/graphs/graph/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! # Example
 //! ```
-//! use graph::{build_graph_from_string, Graph};
+//! use graph::Graph;
 //!
 //! let graph: Graph = "4 3
 //!     1 2 150
@@ -33,5 +33,5 @@ mod reader;
 mod structures;
 
 pub use crate::errors::{AddingEdgeError, BuildGraphError, GraphParametersParsingError, ParsingEdgeError, Result};
-pub use crate::reader::{build_graph_from_file, build_graph_from_string};
+pub use crate::reader::build_graph;
 pub use crate::structures::{Edge, EdgeDescription, Graph, GraphBuilder, GraphParameters};

--- a/graphs/graph/src/reader.rs
+++ b/graphs/graph/src/reader.rs
@@ -35,8 +35,7 @@ pub fn build_graph_from_file<P: AsRef<Path>>(filename: P) -> Result<Graph> {
 /// ```
 /// use graph::build_graph_from_string;
 ///
-/// let input = String::from("
-/// 4 3
+/// let input = String::from("4 3
 /// 1 2 100
 /// 2 3 200
 /// 4 1 125");

--- a/graphs/graph/src/reader.rs
+++ b/graphs/graph/src/reader.rs
@@ -6,9 +6,23 @@ use std::convert::TryFrom;
 use std::fs;
 use std::path::Path;
 
+
 /// Builds a directed graph from txt file with specific format
 ///
-/// First line of txt file should contain two positive integers - number of nodes in the graph (`nodes_count`)
+/// File should be formatted as in [`build_graph_from_string`]
+///
+/// # Arguments
+///
+/// * `filename` - path to file containing input
+pub fn build_graph_from_file<P: AsRef<Path>>(filename: P) -> Result<Graph> {
+    let filename = filename.as_ref();
+    let input = fs::read_to_string(filename)?;
+    build_graph_from_string(input)
+}
+
+/// Builds a directed graph from string with specific format
+///
+/// First line of string should contain two positive integers - number of nodes in the graph (`nodes_count`)
 /// and number of edges in the graph (`edges_count`).
 ///
 /// Then, every line describes one of the `edges_count` edges and contains three integers:
@@ -17,21 +31,28 @@ use std::path::Path;
 /// * Second - Index of node where edge ends ([`Edge::to_index`])
 /// * Third - weight of the edge ([`Edge::weight`])
 ///
-/// # File example
+/// # Example
 /// ```
-/// 4 3
+/// use graph::build_graph_from_string;
+///
+/// let input = String::from(
+/// "4 3
 /// 1 2 100
 /// 2 3 200
-/// 4 1 125
-/// ```
+/// 4 1 125");
 ///
+/// let graph = build_graph_from_string(input).unwrap();
+///
+/// assert_eq!(graph.nodes_count, 4);
+/// assert_eq!(graph.edges.len(), 3);
+/// assert_eq!(graph.edges[0], "1 2 100".parse().unwrap());
+/// assert_eq!(graph.edges[1], "2 3 200".parse().unwrap());
+/// assert_eq!(graph.edges[2], "4 1 125".parse().unwrap());
+///```
 /// # Arguments
 ///
-/// * `filename` - path to file containing graph data
-pub fn build_graph_from_file<P: AsRef<Path>>(filename: P) -> Result<Graph> {
-    let filename = filename.as_ref();
-    let input = fs::read_to_string(filename)?;
-
+/// * `input` - string containing graph data
+pub fn build_graph_from_string(input: String) -> Result<Graph> {
     let mut graph_file_reader = GraphFileReader::new(&input);
 
     let graph_parameters = graph_file_reader.graph_parameters()?;

--- a/graphs/graph/src/reader.rs
+++ b/graphs/graph/src/reader.rs
@@ -5,6 +5,7 @@ use crate::{BuildGraphError, GraphParametersParsingError, Result};
 use std::convert::TryFrom;
 use std::fs;
 use std::path::Path;
+use std::str::FromStr;
 
 
 /// Builds a directed graph from txt file with specific format
@@ -17,7 +18,7 @@ use std::path::Path;
 pub fn build_graph_from_file<P: AsRef<Path>>(filename: P) -> Result<Graph> {
     let filename = filename.as_ref();
     let input = fs::read_to_string(filename)?;
-    build_graph_from_string(input)
+    build_graph_from_string(input.as_str())
 }
 
 /// Builds a directed graph from string with specific format
@@ -33,14 +34,14 @@ pub fn build_graph_from_file<P: AsRef<Path>>(filename: P) -> Result<Graph> {
 ///
 /// # Example
 /// ```
-/// use graph::build_graph_from_string;
+/// use graph::{build_graph_from_string, Graph};
 ///
-/// let input = String::from("4 3
-/// 1 2 100
-/// 2 3 200
-/// 4 1 125");
-///
-/// let graph = build_graph_from_string(input).unwrap();
+/// let graph: Graph = "4 3
+///     1 2 100
+///     2 3 200
+///     4 1 125"
+///     .parse()
+///     .unwrap();
 ///
 /// assert_eq!(graph.nodes_count, 4);
 /// assert_eq!(graph.edges.len(), 3);
@@ -51,8 +52,8 @@ pub fn build_graph_from_file<P: AsRef<Path>>(filename: P) -> Result<Graph> {
 /// # Arguments
 ///
 /// * `input` - string containing graph data
-pub fn build_graph_from_string(input: String) -> Result<Graph> {
-    let mut graph_file_reader = GraphFileReader::new(&input);
+pub fn build_graph_from_string(input: &str) -> Result<Graph> {
+    let mut graph_file_reader = GraphFileReader::new(input);
 
     let graph_parameters = graph_file_reader.graph_parameters()?;
 
@@ -68,6 +69,14 @@ pub fn build_graph_from_string(input: String) -> Result<Graph> {
     }
 
     graph_builder.build()
+}
+
+impl FromStr for Graph {
+    type Err = BuildGraphError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        build_graph_from_string(s)
+    }
 }
 
 type DataIter<'a> = std::str::Lines<'a>;

--- a/graphs/graph/src/reader.rs
+++ b/graphs/graph/src/reader.rs
@@ -35,8 +35,8 @@ pub fn build_graph_from_file<P: AsRef<Path>>(filename: P) -> Result<Graph> {
 /// ```
 /// use graph::build_graph_from_string;
 ///
-/// let input = String::from(
-/// "4 3
+/// let input = String::from("
+/// 4 3
 /// 1 2 100
 /// 2 3 200
 /// 4 1 125");

--- a/graphs/graph/src/structures.rs
+++ b/graphs/graph/src/structures.rs
@@ -1,16 +1,36 @@
+#![warn(missing_docs)]
+
 use super::dfs::dfs;
 use crate::{AddingEdgeError, BuildGraphError, GraphParametersParsingError, ParsingEdgeError, Result};
 use std::convert::TryFrom;
 use std::str::FromStr;
 
+/// Basic element of an directed graph, connects ordered pair of nodes(`from_index`, `to_index`)
+///
+/// # Example
+/// ```
+/// use graph::Edge;
+///
+/// let edge = Edge::new(1, 2, 200);
+///
+/// assert_eq!(edge.from_index, 1);
+/// assert_eq!(edge.to_index, 2);
+/// assert_eq!(edge.weight, 200);
+/// ```
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Edge {
+    /// Number of the node, where edge starts
     pub from_index: u32,
+
+    /// Number of the node, where edge ends
     pub to_index:   u32,
+
+    /// Edge weight
     pub weight:     i32,
 }
 
 impl Edge {
+    /// Creates new edge from integers
     pub fn new(from_index: u32, to_index: u32, weight: i32) -> Edge {
         Edge {
             from_index,
@@ -29,10 +49,17 @@ impl FromStr for Edge {
     }
 }
 
+/// Struct containing slices, might be converted to [`Edge`]
+/// only if slices are parsable to u32 or i32 (depending on the field)
 #[derive(Debug)]
 pub struct EdgeDescription<'a> {
+    /// Number of the node, where edge starts
     pub from_index: &'a str,
+
+    /// Number of the node, where edge ends
     pub to_index:   &'a str,
+
+    /// Edge weight
     pub weight:     &'a str,
 }
 
@@ -86,25 +113,79 @@ impl<'a> TryFrom<EdgeDescription<'a>> for Edge {
     }
 }
 
+/// Directed graph, containing edges list and number of nodes
+///
+/// Could be built using [`crate::build_graph_from_string`], [`crate::build_graph_from_file`] or [`GraphBuilder::build`]
+///
+/// # Example
+/// ```
+/// use graph::build_graph_from_string;
+///
+/// let input = String::from("3 2
+/// 1 3 250
+/// 2 1 120");
+///
+/// let graph = build_graph_from_string(input).unwrap();
+///
+/// assert_eq!(graph.nodes_count, 3);
+/// assert_eq!(graph.edges.len(), 2);
+/// assert_eq!(graph.edges[0], "1 3 250".parse().unwrap());
+/// assert_eq!(graph.edges[1], "2 1 120".parse().unwrap());
+/// ```
 #[derive(Debug)]
 pub struct Graph {
+    /// Number of nodes in graph (indexed from 1 to `nodes_count`)
     pub nodes_count: u32,
+
+    /// Vector of edges
     pub edges:       Vec<Edge>,
 }
 
 impl Graph {
+    /// Creates graph from number of nodes and vector of edges
     pub fn new(nodes_count: u32, edges: Vec<Edge>) -> Graph {
         Graph { nodes_count, edges }
     }
 }
 
+/// Structure used for building a graph (adding edges from input file/string)
+///
+/// # Example
+/// ```
+/// use graph::{GraphParameters, GraphBuilder, Edge};
+///
+/// let graph_parameters = GraphParameters {
+///     nodes_count: 3,
+///     edges_count: 2,
+/// };
+///
+/// let mut graph_builder = GraphBuilder::new(graph_parameters);
+///
+/// let first_edge = Edge::new(1, 3, 250);
+/// graph_builder.add_edge(first_edge);
+///
+/// let second_edge = Edge::new(2, 3, 180);
+/// graph_builder.add_edge(second_edge);
+///
+/// let graph = graph_builder.build().unwrap();
+///
+/// assert_eq!(graph.nodes_count, 3);
+/// assert_eq!(graph.edges[0], first_edge);
+/// assert_eq!(graph.edges[1], second_edge);
+/// ```
 pub struct GraphBuilder {
+    /// Number of nodes in graph
     nodes_count:     u32,
+
+    /// Max number of edges in graph
     max_edges_count: usize,
+
+    /// Vector of edges
     edges:           Vec<Edge>,
 }
 
 impl GraphBuilder {
+    /// Creates empty graph builder using [`GraphParameters`]
     pub fn new(gp: GraphParameters) -> GraphBuilder {
         let GraphParameters {
             nodes_count,
@@ -118,6 +199,10 @@ impl GraphBuilder {
         }
     }
 
+    /// Adds edge to the graph
+    ///
+    /// Returns empty result or [`crate::BuildGraphError`] if GraphBuilder is full or
+    /// one of the indices is invalid
     pub fn add_edge(&mut self, edge: Edge) -> Result<()> {
         if self.edges.len() >= self.max_edges_count {
             return Err(BuildGraphError::from(AddingEdgeError::TooManyEdges {
@@ -164,6 +249,10 @@ impl GraphBuilder {
         true
     }
 
+    /// Builds [`Graph`] from GraphBuilder
+    ///
+    /// Returns [`Graph`] wrapped in result or wrapped [`crate::BuildGraphError`] if builder contains less edges than
+    /// declared or graph isn't connected
     pub fn build(self) -> Result<Graph> {
         if self.edges.len() < self.max_edges_count {
             return Err(BuildGraphError::TooFewEdges {
@@ -182,13 +271,28 @@ impl GraphBuilder {
 
 // -----------------------------------------------------------------------------
 
+/// Number of nodes and edges in the graph
+///
+/// # Example
+/// ```
+/// use graph::GraphParameters;
+///
+/// let graph_parameters = GraphParameters::new(4, 3);
+///
+/// assert_eq!(graph_parameters.nodes_count, 4);
+/// assert_eq!(graph_parameters.edges_count, 3);
+/// ```
 #[derive(Debug)]
 pub struct GraphParameters {
+    /// Number of nodes in the graph (indexed from 1 to `nodes_count`)
     pub nodes_count: u32,
+
+    /// Number of edges in the graph
     pub edges_count: usize,
 }
 
 impl GraphParameters {
+    /// Creates GraphParameters from two integers
     pub fn new(nodes_count: u32, max_edges_count: usize) -> GraphParameters {
         GraphParameters {
             nodes_count,

--- a/graphs/graph/src/structures.rs
+++ b/graphs/graph/src/structures.rs
@@ -143,6 +143,11 @@ pub struct Graph {
 
 impl Graph {
     /// Creates graph from number of nodes and vector of edges
+    ///
+    /// # Arguments
+    ///
+    /// * `nodes_count` - number of nodes in the graph
+    /// * `edges` - vector of [`crate::Edge`]
     pub fn new(nodes_count: u32, edges: Vec<Edge>) -> Graph {
         Graph { nodes_count, edges }
     }
@@ -186,6 +191,10 @@ pub struct GraphBuilder {
 
 impl GraphBuilder {
     /// Creates empty graph builder using [`GraphParameters`]
+    ///
+    /// # Arguments
+    ///
+    /// * `gp` - [`crate::GraphParameters`] containing number of nodes and edges in the graph
     pub fn new(gp: GraphParameters) -> GraphBuilder {
         let GraphParameters {
             nodes_count,
@@ -203,6 +212,10 @@ impl GraphBuilder {
     ///
     /// Returns empty result or [`crate::BuildGraphError`] if GraphBuilder is full or
     /// one of the indices is invalid
+    ///
+    /// # Arguments
+    ///
+    /// * `edge` - edge that will be added to the builder
     pub fn add_edge(&mut self, edge: Edge) -> Result<()> {
         if self.edges.len() >= self.max_edges_count {
             return Err(BuildGraphError::from(AddingEdgeError::TooManyEdges {
@@ -293,6 +306,11 @@ pub struct GraphParameters {
 
 impl GraphParameters {
     /// Creates GraphParameters from two integers
+    ///
+    /// # Arguments
+    ///
+    /// * `nodes_count` - positive integer indicating, how many nodes graph contains
+    /// * `max_edges_count` - positive integer indicating, how many edges graph might contain
     pub fn new(nodes_count: u32, max_edges_count: usize) -> GraphParameters {
         GraphParameters {
             nodes_count,

--- a/graphs/graph/src/structures.rs
+++ b/graphs/graph/src/structures.rs
@@ -30,7 +30,7 @@ pub struct Edge {
 }
 
 impl Edge {
-    /// Creates new edge from integers
+    /// Edge constructor
     pub fn new(from_index: u32, to_index: u32, weight: i32) -> Edge {
         Edge {
             from_index,
@@ -119,13 +119,13 @@ impl<'a> TryFrom<EdgeDescription<'a>> for Edge {
 ///
 /// # Example
 /// ```
-/// use graph::build_graph_from_string;
+/// use graph::Graph;
 ///
-/// let input = String::from("3 2
-/// 1 3 250
-/// 2 1 120");
-///
-/// let graph = build_graph_from_string(input).unwrap();
+/// let graph: Graph = "3 2
+///     1 3 250
+///     2 1 120"
+///     .parse()
+///     .unwrap();
 ///
 /// assert_eq!(graph.nodes_count, 3);
 /// assert_eq!(graph.edges.len(), 2);

--- a/graphs/graph/tests/acceptance_tests.rs
+++ b/graphs/graph/tests/acceptance_tests.rs
@@ -1,12 +1,16 @@
-use graph::{
-    build_graph_from_file,
-    AddingEdgeError,
-    BuildGraphError,
-    Edge,
-    GraphParametersParsingError,
-    ParsingEdgeError,
-};
+use graph::{build_graph, AddingEdgeError, BuildGraphError, Edge, GraphParametersParsingError, ParsingEdgeError};
+use std::path::PathBuf;
 use test_case::test_case;
+
+// -----------------------------------------------------------------------------
+
+fn build_path(dir: &str, graph_file: &str) -> PathBuf {
+    let mut path = PathBuf::from(dir);
+    path.push(graph_file);
+    path.set_extension("txt");
+
+    path
+}
 
 // -----------------------------------------------------------------------------
 
@@ -27,8 +31,8 @@ BuildGraphError::from(GraphParametersParsingError::EdgesCountValueIsNotInteger("
 "error_parsing_graph_parameters_edges_count"
 )]
 fn test_parsing_graph_parameters_errors(graph_file: &str, expected_error: BuildGraphError) {
-    let actual_error =
-        build_graph_from_file(format!("tests/data/parsing_graph_parameters_errors/{}.txt", graph_file)).unwrap_err();
+    let path = build_path("tests/data/parsing_graph_parameters_errors", graph_file);
+    let actual_error = build_graph(&path).unwrap_err();
     assert_eq!(actual_error.to_string(), expected_error.to_string());
 }
 
@@ -74,7 +78,8 @@ edge: Edge{ from_index: 1, to_index: 4, weight: 100, },
 nodes_count: 3, }); "error_adding_edge_wrong_to_index"
 )]
 fn test_edge_errors(graph_file: &str, expected_line_no_with_error: usize, expected_error: BuildGraphError) {
-    let result = build_graph_from_file(format!("tests/data/edge_errors/{}.txt", graph_file)).unwrap_err();
+    let path = build_path("tests/data/edge_errors", graph_file);
+    let result = build_graph(&path).unwrap_err();
 
     if let BuildGraphError::ErrorInGraphDescriptionFile {
         line_no: actual_line_no_with_error,
@@ -93,8 +98,8 @@ fn test_edge_errors(graph_file: &str, expected_line_no_with_error: usize, expect
 #[test_case("error_graph_not_connected", BuildGraphError::GraphNotConnected)]
 #[test_case("error_too_few_edges", BuildGraphError::TooFewEdges{current_count: 3, declared: 4})]
 fn test_graph_building_errors(graph_file: &str, expected_error: BuildGraphError) {
-    let actual_error =
-        build_graph_from_file(format!("tests/data/graph_building_errors/{}.txt", graph_file)).unwrap_err();
+    let path = build_path("tests/data/graph_building_errors", graph_file);
+    let actual_error = build_graph(&path).unwrap_err();
 
     assert_eq!(actual_error.to_string(), expected_error.to_string());
 }

--- a/graphs/runner/src/main.rs
+++ b/graphs/runner/src/main.rs
@@ -46,7 +46,7 @@ fn file_exists(p: &str) -> aResult<()> {
 fn run() -> Result<()> {
     let cmd_args: CmdArgs = CmdArgs::parse();
 
-    let graph = graph::build_graph_from_file(cmd_args.task_file)?;
+    let graph = graph::build_graph(&cmd_args.task_file)?;
     let output = algorithms::calculate_min_total_weight(graph);
     println!("{}", output);
 


### PR DESCRIPTION
**Uwaga**: do zmergowania po wcześniejszym zmergowaniu branch-a **documentation** (zresztą rodzicem tego branch-a i tak jest branch **documentation**).

Dodałem funkcję (pub) `build_graph`, w której to typ parametru wejściowego określa skąd pochodzą dane.
Funkcje `build_graph_from_file` i `build_graph_from_string` są już teraz prywatne.

Widać tutaj przykład użycia **niejawnych** konwersji:
`&str `-> `DataSource`,
`&PathBuf` -> `DataSource`,
`&Path` -> `DataSource`