### PR TITLE
Pdo refactoring in acceptance tests v2

### DIFF
--- a/graphs/graph/tests/acceptance_tests.rs
+++ b/graphs/graph/tests/acceptance_tests.rs
@@ -12,30 +12,43 @@ fn build_path(dir: &str, graph_file: &str) -> PathBuf {
     path
 }
 
-// -----------------------------------------------------------------------------
-
-#[test_case("error_parsing_graph_parameters_empty_input",
-BuildGraphError::from(GraphParametersParsingError::EmptyInput);
-"error_parsing_graph_parameters_empty_input"
-)]
-#[test_case("error_parsing_graph_parameters_missing_edges_count",
-BuildGraphError::from(GraphParametersParsingError::MissingEdgesCountValue);
-"error_parsing_graph_parameters_missing_edges_count"
-)]
-#[test_case("error_parsing_graph_parameters_nodes_count",
-BuildGraphError::from(GraphParametersParsingError::NodesCountValueMustBeInteger("X".to_owned()));
-"error_parsing_graph_parameters_nodes_count"
-)]
-#[test_case("error_parsing_graph_parameters_edges_count",
-BuildGraphError::from(GraphParametersParsingError::EdgesCountValueIsNotInteger("X".to_owned()));
-"error_parsing_graph_parameters_edges_count"
-)]
-fn test_parsing_graph_parameters_errors(graph_file: &str, expected_error: BuildGraphError) {
-    let path = build_path("tests/data/parsing_graph_parameters_errors", graph_file);
+fn validate_graph_file(dir_name: &str, graph_file: &str, expected_error: BuildGraphError) {
+    let path = build_path(dir_name, graph_file);
     let actual_error = build_graph(&path).unwrap_err();
+
     assert_eq!(actual_error.to_string(), expected_error.to_string());
 }
 
+// -----------------------------------------------------------------------------
+// When the first line in the graph description file is invalid
+// -----------------------------------------------------------------------------
+
+#[test_case("error_parsing_graph_parameters_empty_input",
+            GraphParametersParsingError::EmptyInput;
+            "error_parsing_graph_parameters_empty_input"
+)]
+#[test_case("error_parsing_graph_parameters_missing_edges_count",
+            GraphParametersParsingError::MissingEdgesCountValue;
+            "error_parsing_graph_parameters_missing_edges_count"
+)]
+#[test_case("error_parsing_graph_parameters_nodes_count",
+            GraphParametersParsingError::NodesCountValueMustBeInteger("X".to_owned());
+            "error_parsing_graph_parameters_nodes_count"
+)]
+#[test_case("error_parsing_graph_parameters_edges_count",
+            GraphParametersParsingError::EdgesCountValueIsNotInteger("X".to_owned());
+            "error_parsing_graph_parameters_edges_count"
+)]
+fn test_parsing_graph_parameters_errors(graph_file: &str, expected_error: GraphParametersParsingError) {
+    validate_graph_file(
+        "tests/data/parsing_graph_parameters_errors",
+        graph_file,
+        BuildGraphError::from(expected_error),
+    );
+}
+
+// -----------------------------------------------------------------------------
+// When lines: 2..EOF in the graph description file are invalid
 // -----------------------------------------------------------------------------
 
 #[test_case("error_parsing_edge_non_integer_from_index", 2,
@@ -79,27 +92,24 @@ nodes_count: 3, }); "error_adding_edge_wrong_to_index"
 )]
 fn test_edge_errors(graph_file: &str, expected_line_no_with_error: usize, expected_error: BuildGraphError) {
     let path = build_path("tests/data/edge_errors", graph_file);
-    let result = build_graph(&path).unwrap_err();
+    let actual_error = build_graph(&path).unwrap_err();
 
     if let BuildGraphError::ErrorInGraphDescriptionFile {
         line_no: actual_line_no_with_error,
         error: actual_error,
-    } = result
+    } = actual_error
     {
         assert_eq!(actual_line_no_with_error, expected_line_no_with_error);
         assert_eq!(actual_error.to_string(), expected_error.to_string());
     } else {
-        panic!("invalid error !")
+        panic!("unexpected error !")
     }
 }
 
 // -----------------------------------------------------------------------------
 
-#[test_case("error_graph_not_connected", BuildGraphError::GraphNotConnected)]
-#[test_case("error_too_few_edges", BuildGraphError::TooFewEdges{current_count: 3, declared: 4})]
+#[test_case("error_graph_not_connected", BuildGraphError::GraphNotConnected; "error_graph_not_connected")]
+#[test_case("error_too_few_edges", BuildGraphError::TooFewEdges{current_count: 3, declared: 4}; "error_too_few_edges")]
 fn test_graph_building_errors(graph_file: &str, expected_error: BuildGraphError) {
-    let path = build_path("tests/data/graph_building_errors", graph_file);
-    let actual_error = build_graph(&path).unwrap_err();
-
-    assert_eq!(actual_error.to_string(), expected_error.to_string());
+    validate_graph_file("tests/data/graph_building_errors", graph_file, expected_error);
 }

--- a/graphs/graph/tests/acceptance_tests.rs
+++ b/graphs/graph/tests/acceptance_tests.rs
@@ -52,45 +52,53 @@ fn test_parsing_graph_parameters_errors(graph_file: &str, expected_error: GraphP
 // -----------------------------------------------------------------------------
 
 #[test_case("error_parsing_edge_non_integer_from_index", 2,
-BuildGraphError::from(ParsingEdgeError::FromIndexValueMustBeInteger("xyz".to_owned()));
-"error_parsing_edge_non_integer_from_index"
+            ParsingEdgeError::FromIndexValueMustBeInteger("xyz".to_owned());
+            "error_parsing_edge_non_integer_from_index"
 )]
 #[test_case("error_parsing_edge_non_integer_to_index", 2,
-BuildGraphError::from(ParsingEdgeError::ToIndexValueMustBeInteger("abc".to_owned()));
-"error_parsing_edge_non_integer_to_index"
+            ParsingEdgeError::ToIndexValueMustBeInteger("abc".to_owned());
+            "error_parsing_edge_non_integer_to_index"
 )]
 #[test_case("error_parsing_edge_non_integer_weight", 2,
-BuildGraphError::from(ParsingEdgeError::WeightValueMustBeInteger("10a0".to_owned()));
-"error_parsing_edge_non_integer_weight"
+            ParsingEdgeError::WeightValueMustBeInteger("10a0".to_owned());
+            "error_parsing_edge_non_integer_weight"
 )]
 #[test_case("error_parsing_edge_empty_line", 2,
-BuildGraphError::from(ParsingEdgeError::EmptyLine);
-"error_creating_edge_empty_line"
+            ParsingEdgeError::EmptyLine;
+            "error_creating_edge_empty_line"
 )]
 #[test_case("error_parsing_edge_missing_to_index", 4,
-BuildGraphError::from(ParsingEdgeError::MissingToIndexField);
-"error_creating_edge_missing_to_index"
+            ParsingEdgeError::MissingToIndexField;
+            "error_creating_edge_missing_to_index"
 )]
 #[test_case("error_parsing_edge_missing_weight", 3,
-BuildGraphError::from(ParsingEdgeError::MissingWeightField);
-"error_edge_description_missing_weight"
+            ParsingEdgeError::MissingWeightField;
+            "error_edge_description_missing_weight"
 )]
 #[test_case("error_adding_edge_too_many_edges", 4,
-BuildGraphError::from(AddingEdgeError::TooManyEdges{
-edges_count: 3,
-edge: Edge{ from_index: 1, to_index: 4, weight: 200 }}); "error_adding_edge_too_many_edges"
+            AddingEdgeError::TooManyEdges{
+                edges_count: 3,
+                edge: Edge{ from_index: 1, to_index: 4, weight: 200 }
+            };
+            "error_adding_edge_too_many_edges"
 )]
 #[test_case("error_adding_edge_wrong_from_index", 3,
-BuildGraphError::from(AddingEdgeError::WrongFromIndex{
-edge: Edge{ from_index: 5, to_index: 3, weight: 100, },
-nodes_count: 4, }); "error_adding_edge_wrong_from_index"
+            AddingEdgeError::WrongFromIndex{
+                nodes_count: 4,
+                edge: Edge{ from_index: 5, to_index: 3, weight: 100, },
+            };
+            "error_adding_edge_wrong_from_index"
 )]
 #[test_case("error_adding_edge_wrong_to_index", 2,
-BuildGraphError::from(AddingEdgeError::WrongToIndex{
-edge: Edge{ from_index: 1, to_index: 4, weight: 100, },
-nodes_count: 3, }); "error_adding_edge_wrong_to_index"
+            AddingEdgeError::WrongToIndex{
+                nodes_count: 3,
+                edge: Edge{ from_index: 1, to_index: 4, weight: 100, },
+            };
+            "error_adding_edge_wrong_to_index"
 )]
-fn test_edge_errors(graph_file: &str, expected_line_no_with_error: usize, expected_error: BuildGraphError) {
+fn test_edge_errors<E: Into<BuildGraphError>>(graph_file: &str, expected_line_no_with_error: usize, expected_error: E) {
+    let expected_error = expected_error.into();
+
     let path = build_path("tests/data/edge_errors", graph_file);
     let actual_error = build_graph(&path).unwrap_err();
 


### PR DESCRIPTION
Zwróć uwagę w jaki sposób zdefiniowany jest typ parametru `expected_error`.
Teraz nie trzeba już w test_case definiować bezpośrednio obiektu typu `BuildGraphError` - wystarczy, że będzie to obiekt
konwertowalny (Into) do tego typu. 
```rust
fn test_edge_errors<E: Into<BuildGraphError>>(graph_file: &str, expected_line_no_with_error: usize, expected_error: E) {
    let expected_error = expected_error.into();
    ...
```