### PR TITLE
Redundant directory cleanup - issue #68

### DIFF
--- a/graphs/Cargo.lock
+++ b/graphs/Cargo.lock
@@ -285,6 +285,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +311,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "runner"
 version = "0.1.0"
 dependencies = [
@@ -312,6 +330,7 @@ dependencies = [
  "graph",
  "parse-display",
  "rand",
+ "tempfile",
  "termcolor",
  "test-case",
  "thiserror",
@@ -355,6 +374,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]

--- a/graphs/runner/Cargo.toml
+++ b/graphs/runner/Cargo.toml
@@ -32,3 +32,4 @@ version = "~3.0.0-beta.2"
 
 [dev-dependencies]
 test-case = "1.1.0"
+tempfile = "3.2.0"

--- a/graphs/runner/Cargo.toml
+++ b/graphs/runner/Cargo.toml
@@ -4,13 +4,13 @@ version = "0.1.0"
 edition = "2018"
 
 # Copied from https://stackoverflow.com/questions/26946646/rust-package-with-both-a-library-and-a-binary
-[lib]
-name = "runner_lib"
-path = "src/lib.rs"
-
-[[bin]]
-name = "runner_bin"
-path = "src/bin/main.rs"
+#[lib]
+#name = "runner_lib"
+#path = "src/lib.rs"
+#
+#[[bin]]
+#name = "runner_bin"
+#path = "src/bin/main.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/graphs/runner/src/cli.rs
+++ b/graphs/runner/src/cli.rs
@@ -46,7 +46,7 @@ impl SubCommand {
     ///
     /// # Example
     /// ```
-    /// use runner_lib::SubCommand;
+    /// use runner::SubCommand;
     ///
     /// let command_name = "generate-graph-file";
     /// let args = "--graph-file aaa.txt --nodes-count 5 --edges-count 6 --max-weight 100";

--- a/graphs/runner/src/generate_graph.rs
+++ b/graphs/runner/src/generate_graph.rs
@@ -139,7 +139,7 @@ mod tests {
     use super::*;
     use test_case::test_case;
 
-    #[test_case(7, 5 => false; "no beacuse nodes_count is greater than edges_count by more than 1")]
+    #[test_case(7, 5 => false; "no because nodes_count is greater than edges_count by more than 1")]
     #[test_case(6, 5 => true; "yes because nodes_count is greater than edges_count but only by 1")]
     #[test_case(5, 5 => true; "yes because nodes_count is equal edges_count")]
     #[test_case(4, 5 => true; "yes because is more edges than nodes")]

--- a/graphs/runner/src/generate_graph.rs
+++ b/graphs/runner/src/generate_graph.rs
@@ -22,9 +22,24 @@ use std::path::Path;
 /// ```
 /// use runner_lib::{GenerateGraphFileArgs, generate_graph};
 /// use std::path::PathBuf;
+/// use tempfile::tempdir_in;
+/// use graph::build_graph;
 ///
-/// let parameters = "--graph-file test_graph.file.txt --nodes-count 3 --edges-count 5 --max-weight 20".parse::<GenerateGraphFileArgs>().unwrap();
+/// # let temp_dir = tempdir_in("").unwrap();
+/// # let mut temp_file = PathBuf::from(temp_dir.path());
+/// # temp_file.push("test_graph_file.txt");
+///
+/// // `temp_file` is temporary graph file, deleted after running the test
+/// let parameters = format!("--graph-file {} --nodes-count 3 --edges-count 5 --max-weight 20", temp_file.to_str().unwrap())
+///     .parse::<GenerateGraphFileArgs>().unwrap();
 /// let output = generate_graph(&parameters);
+///
+/// assert!(output.is_ok());
+///
+/// // check if generated graph is correct
+/// let build_result = build_graph(temp_file.as_path());
+/// println!("{:?}", build_result);
+/// assert!(build_result.is_ok());
 /// ```
 ///
 /// # Possible output

--- a/graphs/runner/src/generate_graph.rs
+++ b/graphs/runner/src/generate_graph.rs
@@ -30,15 +30,15 @@ use std::path::Path;
 /// # temp_file.push("test_graph_file.txt");
 ///
 /// // `temp_file` is temporary graph file, deleted after running the test
-/// let parameters = format!("--graph-file {} --nodes-count 3 --edges-count 5 --max-weight 20", temp_file.to_str().unwrap())
-///     .parse::<GenerateGraphFileArgs>().unwrap();
-/// let output = generate_graph(&parameters);
+/// let parameters = format!("--graph-file {} --nodes-count 3 --edges-count 5 --max-weight 20",
+/// temp_file.to_str().unwrap()).parse::<GenerateGraphFileArgs>().unwrap();
+/// let result = generate_graph(&parameters);
 ///
-/// assert!(output.is_ok());
+/// assert!(result.is_ok());
+/// assert!(temp_file.exists());
 ///
 /// // check if generated graph is correct
 /// let build_result = build_graph(temp_file.as_path());
-/// println!("{:?}", build_result);
 /// assert!(build_result.is_ok());
 /// ```
 ///

--- a/graphs/runner/src/generate_graph.rs
+++ b/graphs/runner/src/generate_graph.rs
@@ -20,7 +20,7 @@ use std::path::Path;
 ///
 /// # Example
 /// ```
-/// use runner_lib::{GenerateGraphFileArgs, generate_graph};
+/// use runner::{GenerateGraphFileArgs, generate_graph};
 /// use std::path::PathBuf;
 /// use tempfile::tempdir_in;
 /// use graph::build_graph;

--- a/graphs/runner/src/generate_graph.rs
+++ b/graphs/runner/src/generate_graph.rs
@@ -71,7 +71,7 @@ pub fn generate_graph(parameters: &GenerateGraphFileArgs) -> Result<()> {
     let edges_left = calculate_edges_left(parameters.nodes_count, parameters.edges_count);
 
     // generate rest of edges using `rng`
-    for _ in 0..=edges_left {
+    for _ in 0..edges_left {
         output
             .write_all(
                 format!(

--- a/graphs/runner/src/lib.rs
+++ b/graphs/runner/src/lib.rs
@@ -7,7 +7,3 @@ pub use cli::*;
 pub use errors::{GenerateGraphError, RunnerError};
 pub use generate_graph::generate_graph;
 pub use subcommands::*;
-
-pub fn test() {
-    println!("TEST");
-}

--- a/graphs/runner/src/main.rs
+++ b/graphs/runner/src/main.rs
@@ -1,9 +1,8 @@
 use clap::Clap;
+use runner::*;
 use std::io::{self, Write};
 use std::process;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
-
-use runner_lib::*;
 
 type Result<T, E = RunnerError> = std::result::Result<T, E>;
 

--- a/graphs/runner/tests/graph_file_generator_subcommands.rs
+++ b/graphs/runner/tests/graph_file_generator_subcommands.rs
@@ -96,11 +96,13 @@ mod passing_tests {
 
         let graph_result = build_graph(temp_file.as_path());
 
-        println!("{:?}", graph_result);
-
-        assert!(graph_result.is_ok());
-
-        temp_dir.close()?;
+        // temp_dir is deleted even if the tests panics so I use this if statement to keep it
+        if !graph_result.is_ok() {
+            // keep temp_dir as a normal directory
+            temp_dir.into_path();
+            // panic because of an error
+            panic!("{:?}", graph_result.unwrap_err());
+        }
 
         Ok(())
     }

--- a/graphs/runner/tests/graph_file_generator_subcommands.rs
+++ b/graphs/runner/tests/graph_file_generator_subcommands.rs
@@ -73,23 +73,37 @@ mod failing_tests {
 
 mod passing_tests {
     use super::*;
+    use algorithms::calculate_min_total_weight;
+    use graph::build_graph;
     use std::path::PathBuf;
     use tempfile::tempdir_in;
 
     #[test]
     fn ok() -> Result<()> {
         let temp_dir = tempdir_in(".")?;
-        let file_path = PathBuf::from(temp_dir.path()).push("test_graph_file.txt");
+        let mut temp_file = PathBuf::from(temp_dir.path());
+        temp_file.push("test_graph_file.txt");
+
+        // let file_path = PathBuf::from(temp_dir.path()).push("test_graph_file.txt");
+
+        println!("{:?}", temp_file);
 
         let parameters = format!(
-            "--graph-file {:?} --nodes-count 5 --edges-count 4 --max-weight 100",
-            file_path
+            "--graph-file {} --nodes-count 5 --edges-count 4 --max-weight 100",
+            temp_file.clone().into_os_string().into_string().unwrap()
         )
         .parse::<GenerateGraphFileArgs>()?;
 
         let result = generate_graph(&parameters);
 
+        print!("{:?}", result);
+
         assert!(result.is_ok());
+        assert!(temp_file.exists());
+
+        // doesn't work yet
+        // let graph_result = build_graph(temp_file.into_os_string().into_string().unwrap().as_str());
+        // assert!(graph_result.is_ok());
 
         temp_dir.close()?;
 

--- a/graphs/runner/tests/graph_file_generator_subcommands.rs
+++ b/graphs/runner/tests/graph_file_generator_subcommands.rs
@@ -1,4 +1,4 @@
-use runner_lib::*;
+use runner::*;
 
 use anyhow::Result;
 

--- a/graphs/runner/tests/graph_file_generator_subcommands.rs
+++ b/graphs/runner/tests/graph_file_generator_subcommands.rs
@@ -73,37 +73,32 @@ mod failing_tests {
 
 mod passing_tests {
     use super::*;
-    use algorithms::calculate_min_total_weight;
     use graph::build_graph;
     use std::path::PathBuf;
     use tempfile::tempdir_in;
 
     #[test]
     fn ok() -> Result<()> {
-        let temp_dir = tempdir_in(".")?;
+        let temp_dir = tempdir_in("")?;
         let mut temp_file = PathBuf::from(temp_dir.path());
         temp_file.push("test_graph_file.txt");
 
-        // let file_path = PathBuf::from(temp_dir.path()).push("test_graph_file.txt");
-
-        println!("{:?}", temp_file);
-
         let parameters = format!(
             "--graph-file {} --nodes-count 5 --edges-count 4 --max-weight 100",
-            temp_file.clone().into_os_string().into_string().unwrap()
+            temp_file.to_str().unwrap()
         )
         .parse::<GenerateGraphFileArgs>()?;
 
         let result = generate_graph(&parameters);
 
-        print!("{:?}", result);
-
         assert!(result.is_ok());
         assert!(temp_file.exists());
 
-        // doesn't work yet
-        // let graph_result = build_graph(temp_file.into_os_string().into_string().unwrap().as_str());
-        // assert!(graph_result.is_ok());
+        let graph_result = build_graph(temp_file.as_path());
+
+        println!("{:?}", graph_result);
+
+        assert!(graph_result.is_ok());
 
         temp_dir.close()?;
 

--- a/graphs/runner/tests/graph_file_generator_subcommands.rs
+++ b/graphs/runner/tests/graph_file_generator_subcommands.rs
@@ -73,19 +73,26 @@ mod failing_tests {
 
 mod passing_tests {
     use super::*;
+    use std::path::PathBuf;
+    use tempfile::tempdir_in;
 
     #[test]
     fn ok() -> Result<()> {
-        // let parameters = GenerateGraphFileArgs::try_from_args(
-        //     "--graph-file aaa.txt --nodes-count 5 --edges-count 4 --max-weight 100",
-        // )?;
-        let parameters = "--graph-file aaa.txt --nodes-count 5 --edges-count 4 --max-weight 100"
-            .parse::<GenerateGraphFileArgs>()
-            .unwrap();
+        let temp_dir = tempdir_in(".")?;
+        let file_path = PathBuf::from(temp_dir.path()).push("test_graph_file.txt");
+
+        let parameters = format!(
+            "--graph-file {:?} --nodes-count 5 --edges-count 4 --max-weight 100",
+            file_path
+        )
+        .parse::<GenerateGraphFileArgs>()
+        .unwrap();
 
         let result = generate_graph(&parameters);
 
         assert!(result.is_ok());
+
+        temp_dir.close()?;
 
         Ok(())
     }


### PR DESCRIPTION
In runner crate: move `main.rs` out of `bin` directory and delete this directory.