### PR TITLE
Extend the default logger configuration

### DIFF
--- a/utils/Cargo.lock
+++ b/utils/Cargo.lock
@@ -465,6 +465,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "atty",
+ "cfg-if",
  "clap",
  "derive_more",
  "flexi_logger",

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 [features]
 default = []
 default_logging = ["flexi_logger"]
-required_features = ["default_logging"]
 
 [dependencies]
 atty = "0.2"
+cfg-if = "1.0"
 clap = "~3.0.0-beta.2"
 
 derive_more = "0.99"
@@ -30,3 +30,7 @@ anyhow = "1.0"
 
 [dev-dependencies]
 test-case = "1.1.0"
+
+[[example]]
+name = "use_default_logging"
+required-features = ["default_logging"]

--- a/utils/examples/use_default_logging/main.rs
+++ b/utils/examples/use_default_logging/main.rs
@@ -1,27 +1,31 @@
+/// You can run this program with the following command e.g.:
+///
+/// RUST_LOG=error,use_default_logging=warn cargo run --example use_default_logging --features default_logging
+///
+mod cmd_args;
+
 use cmd_args::CmdArgs;
-use log::info;
+use log::warn;
 use thiserror::Error;
 use utils::ApplicationRunner;
 
-mod cmd_args;
+#[derive(Debug, Error)]
+#[error("Application error !")]
+struct AppError;
+
+struct App;
 
 fn main() {
     App.main();
 }
-
-struct App;
 
 impl ApplicationRunner for App {
     type CmdArgs = CmdArgs;
     type Error = AppError;
 
     fn run(&self, _cmd_args: CmdArgs) -> Result<(), Self::Error> {
-        println!("hello");
-        info!("info -> hello");
-        Ok(())
+        warn!("this method will raise an error");
+
+        Err(AppError)
     }
 }
-
-#[derive(Debug, Error)]
-#[error("App error")]
-struct AppError;


### PR DESCRIPTION
I'm not happy with this:
```rust
cfg_if::cfg_if! {
    if #[cfg(feature = "default_logging")] {
        let _app_logger_handle: flexi_logger::LoggerHandle = self.configure_logging();
    } else {
        self.configure_logging();
    }
}
```
but so far I have no better idea.

You may ask why I'm doing this - please read this piece of _flexi_logger_ documentation:
 _Keep the LoggerHandle alive up to the very end of your program! Dropping the LoggerHandle flushes and shuts down FileLogWriters and other LogWriters, and then may prevent further logging! This should happen immediately before the program terminates, but not earlier._

LoggerHandle is returned by the start() method:
```rust
fn configure_logging(&self) -> flexi_logger::LoggerHandle {
    use flexi_logger::{detailed_format, Duplicate, FileSpec, Logger};

    let _logger_handle = Logger::try_with_env_or_str("warn")
        .unwrap()
        .log_to_file(FileSpec::default().directory(".logs"))
        .duplicate_to_stderr(Duplicate::Warn)
        // .duplicate_to_stderr(Duplicate::All)
        .format_for_files(detailed_format)
        .format_for_stderr(default_colored_format)
        .print_message()
        .create_symlink("current_run") // create a symbolic link to the current log file
        .start()     // <----------------
        .unwrap();

    info!("default logger initialized");

    _logger_handle
}
```